### PR TITLE
replace CHECK_GT -> CHECK_GE

### DIFF
--- a/cartographer/sensor/map_by_time.h
+++ b/cartographer/sensor/map_by_time.h
@@ -40,7 +40,7 @@ class MapByTime {
     CHECK_GE(trajectory_id, 0);
     auto& trajectory = data_[trajectory_id];
     if (!trajectory.empty()) {
-      CHECK_GT(data.time, std::prev(trajectory.end())->first);
+      CHECK_GE(data.time, std::prev(trajectory.end())->first);
     }
     trajectory.emplace(data.time, data);
   }


### PR DESCRIPTION
cartographer_rosを使用した際に発生する以下のエラーに対する修正
```
F0120 14:29:04.615726 15453 map_by_time.h:43] Check failed: data.time > std::prev(trajectory.end())->first (637072362709882836 vs. 637072362709882836) 
[FATAL] [1579498144.615922130, 1571639471.085584511]: F0120 14:29:04.000000 15453 map_by_time.h:43] Check failed: data.time > std::prev(trajectory.end())->first (637072362709882836 vs. 637072362709882836) 
```